### PR TITLE
report: Add space between subject and title separator on header

### DIFF
--- a/zentera/report/report.sty
+++ b/zentera/report/report.sty
@@ -90,7 +90,6 @@
     
     \vspace{1cm}
     {\parindent=0pt \hrulefill} 
-    \vspace{1cm}
 }
 \makeatother
 \endinput

--- a/zentera/report/report.sty
+++ b/zentera/report/report.sty
@@ -81,7 +81,7 @@
     \end{flushleft}
     \vspace{-2.8cm} 
     \hspace{4cm}
-    \parbox{11cm}{{\Large \textbf{\@subject --- \@title}}
+    \parbox{11cm}{{\Large \textbf{\@subject\ --- \@title}}
         
         \textbf{Professor:} \@supervisor
     


### PR DESCRIPTION
The hyphen was being rendered right next to the subject string. This patch adds a space between the subject string and the hyphen so that it is centered between the subject and the title strings.