### PR TITLE
report: Add space between subject and dash on header

### DIFF
--- a/zentera/report/report.sty
+++ b/zentera/report/report.sty
@@ -81,7 +81,7 @@
     \end{flushleft}
     \vspace{-2.8cm} 
     \hspace{4cm}
-    \parbox{11cm}{{\Large \textbf{\@subject --- \@title}}
+    \parbox{11cm}{{\Large \textbf{\@subject\ --- \@title}}
         
         \textbf{Professor:} \@supervisor
     


### PR DESCRIPTION
The dash on the header was being drawn right next to the subject string. This patch fixes this by forcing a space between the subject string and the dash, centralizing the dash between the subject and the title strings.