### PR TITLE
report: Remove vertical space after header

### DIFF
--- a/zentera/report/report.sty
+++ b/zentera/report/report.sty
@@ -90,7 +90,6 @@
     
     \vspace{1cm}
     {\parindent=0pt \hrulefill} 
-    \vspace{1cm}
 }
 \makeatother
 \endinput


### PR DESCRIPTION
The vertical space after the header created an awkward blank space before the text. This removes the vertical space altogether as the result looks better.